### PR TITLE
Revert bionic Docker repo back to xenial

### DIFF
--- a/roles/docker/vars/ubuntu-bionic.yml
+++ b/roles/docker/vars/ubuntu-bionic.yml
@@ -28,5 +28,5 @@ docker_repo_info:
   repos:
     - >
        deb [arch=amd64] {{ docker_ubuntu_repo_base_url }}
-       bionic
+       xenial
        stable


### PR DESCRIPTION
This is just a quick patch to get us working again with Docker 17.03.
This needs to be updated to be smarter before submitting a PR.